### PR TITLE
[FIX] : redux initialize에는 Object.assign 사용

### DIFF
--- a/src/stores/slices/userInputSlice.ts
+++ b/src/stores/slices/userInputSlice.ts
@@ -334,7 +334,7 @@ const userInputSlice = createSlice({
   initialState,
   reducers: {
     initializeInput: state => {
-      state = initialState;
+      Object.assign(state, initialState);
     },
     loadBaseLineData: (state, action: PayloadAction<IBaseLineData>) => {
       // FirstInput


### PR DESCRIPTION
기존에 state = initialState로 초기화를 하면 동작 안함
=> Object.assign을 사용하여 초기화

(23.12.07 : fixed by 현킴)