### PR TITLE
[FEAT]: 자동구성에 원하는 판매자 식품을 포함하는 기능 추가

### DIFF
--- a/src/components/cart/AccordionInactiveHeader.tsx
+++ b/src/components/cart/AccordionInactiveHeader.tsx
@@ -9,7 +9,7 @@ import {icons} from '../../assets/icons/iconSource';
 import {RootState} from '../../stores/store';
 import colors from '../../styles/colors';
 import {commaToNum, sumUpNutrients, sumUpPrice} from '../../util/sumUp';
-import {setMenuActiveSection} from '../../stores/slices/cartSlice';
+import {setMenuActiveSection} from '../../stores/slices/commonSlice';
 
 // doobi Component
 import DAlert from '../common/alert/DAlert';
@@ -51,7 +51,7 @@ const AccordionInactiveHeader = ({
 }: IAccordionInactiveHeader) => {
   // redux
   const dispatch = useDispatch();
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
 
   // react-query
   const {data: dietData} = useListDiet();

--- a/src/components/cart/AutoDietModal.tsx
+++ b/src/components/cart/AutoDietModal.tsx
@@ -8,7 +8,7 @@ import {RootState} from '../../stores/store';
 import {icons} from '../../assets/icons/iconSource';
 import colors from '../../styles/colors';
 import {useAsync} from '../../util/cart/cartCustomHooks';
-import {setCurrentDiet} from '../../stores/slices/cartSlice';
+import {setCurrentDiet} from '../../stores/slices/commonSlice';
 // doobi Component
 import {
   BtnCTA,
@@ -27,6 +27,7 @@ import {IDietDetailData} from '../../query/types/diet';
 import {IProductData} from '../../query/types/product';
 import {useCreateDietDetail, useListDietDetail} from '../../query/queries/diet';
 import {makeAutoMenu2} from '../../util/cart/autoMenu2';
+import Dropdown from '../userInput/Dropdown';
 
 interface IAutoDietModal {
   modalVisible: boolean;
@@ -44,7 +45,9 @@ const AutoDietModal = ({
 }: IAutoDietModal) => {
   // redux
   const dispatch = useDispatch();
-  const {totalFoodList} = useSelector((state: RootState) => state.cart);
+  const {totalFoodList, platformDDItems} = useSelector(
+    (state: RootState) => state.common,
+  );
 
   // react-query
   const {data: baseLineData} = useGetBaseLine();
@@ -56,6 +59,7 @@ const AutoDietModal = ({
   const [selectedCategory, setSelectedCategory] = useState<boolean[]>([]);
   const [sliderValue, setSliderValue] = useState<number[]>([4000, 12000]);
   const [autoFailedNum, setAutoFailedNum] = useState<number>(0);
+  const [wantedPlatform, setWantedPlatform] = useState<string>('');
 
   useEffect(() => {
     categoryData &&
@@ -105,10 +109,11 @@ const AutoDietModal = ({
     asyncFunction: async () => {
       const data = await makeAutoMenu2({
         totalFoodList,
-        initialMenu: dietDetailData, // !!!!!!!!!!!!! 바뀜 !!!!!!!!!!
+        initialMenu: dietDetailData,
         baseLine: baseLineData,
         selectedCategoryIdx,
         priceTarget: sliderValue,
+        wantedPlatform,
       }).then(res => res);
       return data;
     },
@@ -200,7 +205,8 @@ const AutoDietModal = ({
   const renderBaseContent = () => {
     return (
       <ModalContainer>
-        <ModalTitle>
+        {/* 식품유형은 일단 생략 */}
+        {/* <ModalTitle>
           {'추천받을 식품 유형 \n3가지 이상 선택해 주세요'}
         </ModalTitle>
         <CategoryBox>
@@ -225,10 +231,19 @@ const AutoDietModal = ({
         </CategoryBox>
         <HorizontalSpace height={12} />
 
-        <HorizontalLine />
+        <HorizontalLine /> */}
+
+        {/* 해당 판매자 식품을 하나 이상 포함 */}
+        <OptionTitle>{'해당 식품사를 포함해서 자동구성'}</OptionTitle>
+        <Dropdown
+          placeholder="식품사"
+          value={wantedPlatform}
+          setValue={setWantedPlatform}
+          items={platformDDItems}
+        />
 
         {/* 한 끼 가격 슬라이더 */}
-        <SliderTitle>한 끼 가격</SliderTitle>
+        <OptionTitle>한 끼 가격</OptionTitle>
         <DSlider
           sliderValue={sliderValue}
           setSliderValue={setSliderValue}
@@ -358,7 +373,7 @@ const CategoryText = styled(TextMain)`
   font-size: 14px;
 `;
 
-const SliderTitle = styled(TextMain)`
+const OptionTitle = styled(TextMain)`
   font-size: 16px;
   font-weight: bold;
   margin-top: 40px;

--- a/src/components/cart/CartSummary.tsx
+++ b/src/components/cart/CartSummary.tsx
@@ -16,7 +16,7 @@ import {
 
 import {useListDietDetailAll} from '../../query/queries/diet';
 import {useDispatch} from 'react-redux';
-import {setMenuActiveSection} from '../../stores/slices/cartSlice';
+import {setMenuActiveSection} from '../../stores/slices/commonSlice';
 import {View} from 'react-native';
 import {icons} from '../../assets/icons/iconSource';
 import {useNavigation} from '@react-navigation/native';
@@ -153,7 +153,7 @@ const CartSummary = ({
 export default CartSummary;
 
 const TotalSummaryContainer = styled.View`
-  padding: 0px 16px 24px 16px;
+  padding: 0px 16px 80px 16px;
   background-color: ${colors.white};
 `;
 

--- a/src/components/cart/MenuNumSelectContent.tsx
+++ b/src/components/cart/MenuNumSelectContent.tsx
@@ -20,7 +20,10 @@ import {commaToNum, reGroupBySeller, sumUpPrice} from '../../util/sumUp';
 import colors from '../../styles/colors';
 import {findDietSeq} from '../../util/findDietSeq';
 import {BASE_URL} from '../../query/queries/urls';
-import {SCREENWIDTH} from '../../constants/constants';
+import {
+  SCREENWIDTH,
+  SERVICE_PRICE_PER_PRODUCT,
+} from '../../constants/constants';
 
 // react-query
 import {
@@ -80,30 +83,31 @@ const MenuNumSelectContent = ({
             {/* 현재 끼니 식품 리스트 */}
             <HorizontalSpace height={8} />
             {dietDetailData &&
-              dietDetailData.map(
-                (food, idx) =>
-                  idx < 2 && (
-                    <Row key={idx} style={{marginTop: 16}}>
-                      <ThumbnailImg
-                        source={{uri: `${BASE_URL}${food.mainAttUrl}`}}
-                      />
-                      <Col
-                        style={{
-                          flex: 1,
-                          marginLeft: 8,
-                        }}>
-                        <TextGrey>{food.platformNm}</TextGrey>
-                        <Row style={{justifyContent: 'space-between'}}>
-                          <Text numberOfLines={1} ellipsizeMode="tail">
-                            {food.productNm}
-                          </Text>
-                          <TextGrey>{commaToNum(food.price)}원</TextGrey>
-                        </Row>
-                      </Col>
+              dietDetailData.map((food, idx) => (
+                <Row key={idx} style={{marginTop: 16}}>
+                  <ThumbnailImg
+                    source={{uri: `${BASE_URL}${food.mainAttUrl}`}}
+                  />
+                  <Col
+                    style={{
+                      flex: 1,
+                      marginLeft: 8,
+                    }}>
+                    <TextGrey>{food.platformNm}</TextGrey>
+                    <Row style={{justifyContent: 'space-between'}}>
+                      <Text numberOfLines={1} ellipsizeMode="tail">
+                        {food.productNm}
+                      </Text>
+                      <TextGrey>
+                        {commaToNum(
+                          parseInt(food.price) + SERVICE_PRICE_PER_PRODUCT,
+                        )}
+                        원
+                      </TextGrey>
                     </Row>
-                  ),
-              )}
-            <PlusNum>외 {productNum - 2}개 상품</PlusNum>
+                  </Col>
+                </Row>
+              ))}
             <HorizontalLine style={{marginTop: 24}} />
 
             {/* 전체 끼니 중 현재 끼니 상품들 판매자별로 보여주기 */}
@@ -194,13 +198,6 @@ const TextGrey = styled(TextSub)`
 `;
 const Text = styled(TextMain)`
   font-size: 14px;
-`;
-
-const PlusNum = styled(TextSub)`
-  font-size: 12px;
-
-  margin-top: 24px;
-  align-self: center;
 `;
 
 const BtnBox = styled.View`

--- a/src/components/common/menuSection/MenuSection.tsx
+++ b/src/components/common/menuSection/MenuSection.tsx
@@ -31,7 +31,7 @@ import {commaToNum, sumUpPrice} from '../../../util/sumUp';
 
 const MenuSection = () => {
   // redux
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
 
   // react-query
   const {data: dietData} = useListDiet();

--- a/src/components/common/menuSection/MenuSelectCard.tsx
+++ b/src/components/common/menuSection/MenuSelectCard.tsx
@@ -6,7 +6,7 @@ import {RootState} from '../../../stores/store';
 import {
   setCurrentDiet,
   setMenuActiveSection,
-} from '../../../stores/slices/cartSlice';
+} from '../../../stores/slices/commonSlice';
 import {Col, Row, StyledProps} from '../../../styles/styledConsts';
 import colors from '../../../styles/colors';
 import {getDietAddStatus} from '../../../util/getDietAddStatus';
@@ -22,7 +22,7 @@ import {
 
 const MenuSelectCard = () => {
   // redux
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
   const dispatch = useDispatch();
 
   // react-query

--- a/src/components/common/nutrient/NutrientsProgress.tsx
+++ b/src/components/common/nutrient/NutrientsProgress.tsx
@@ -15,7 +15,7 @@ import DTooltip from '../tooltip/DTooltip';
 import {NUTR_ERROR_RANGE, SCREENWIDTH} from '../../../constants/constants';
 import {RootState} from '../../../stores/store';
 import {useDispatch, useSelector} from 'react-redux';
-import {setNutrTooltipText} from '../../../stores/slices/cartSlice';
+import {setNutrTooltipText} from '../../../stores/slices/commonSlice';
 import {useNavigation, useRoute} from '@react-navigation/native';
 import {icons} from '../../../assets/icons/iconSource';
 import {IDietDetailData} from '../../../query/types/diet';
@@ -81,7 +81,7 @@ const NutrientsProgress = ({
   const route = useRoute();
 
   // redux
-  const {nutrTooltipText} = useSelector((state: RootState) => state.cart);
+  const {nutrTooltipText} = useSelector((state: RootState) => state.common);
   const dispatch = useDispatch();
 
   // react-query

--- a/src/components/common/slider/DSlider.tsx
+++ b/src/components/common/slider/DSlider.tsx
@@ -4,6 +4,7 @@ import {Slider} from '@miblanchard/react-native-slider';
 
 import colors from '../../../styles/colors';
 import {StyledProps, TextMain} from '../../../styles/styledConsts';
+import {commaToNum} from '../../../util/sumUp';
 
 interface IDSlider {
   sliderValue: number[];
@@ -44,8 +45,7 @@ const DSlider = ({
           renderAboveThumbComponent={index => (
             <AboveThumbComponent thumbIdx={index}>
               <ThumbText>
-                {sliderValue[index]}
-                {text}
+                {commaToNum(sliderValue[index])}원{text}
               </ThumbText>
             </AboveThumbComponent>
           )}
@@ -74,7 +74,7 @@ const AboveThumbComponent = styled.View`
   width: 56px;
   height: 20px;
   position: absolute;
-  left: -${(56 - THUMB_SIZE) / 2}px;
+  left: -28px;
   top: ${({thumbIdx}: StyledProps) =>
     thumbIdx === 0 ? (THUMB_SIZE / 2) * 3 + 6 : -(THUMB_SIZE / 2 + 6)}px;
   align-items: center;

--- a/src/components/home/Filter.tsx
+++ b/src/components/home/Filter.tsx
@@ -29,7 +29,7 @@ interface IFilter {
 const Filter = ({setFilterModalShow, setSearchBarFocus}: IFilter) => {
   // redux
   const dispatch = useDispatch();
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
   const {applied} = useSelector((state: RootState) => state.sortFilter);
 
   // react-query

--- a/src/components/home/FoodList.tsx
+++ b/src/components/home/FoodList.tsx
@@ -45,7 +45,7 @@ interface IFoodList {
 const FoodList = ({item, screen = 'HomeScreen'}: IFoodList) => {
   const {navigate} = useNavigation();
   // redux
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
 
   // react-query
   const {data: dietDetailData} = useListDietDetail(currentDietNo, {

--- a/src/query/queries/diet.ts
+++ b/src/query/queries/diet.ts
@@ -6,7 +6,7 @@ import {queryClient} from '../store';
 import {
   setCurrentDiet,
   setMenuActiveSection,
-} from '../../stores/slices/cartSlice';
+} from '../../stores/slices/commonSlice';
 import {useHandleError} from '../../util/handleError';
 import {
   DIET,
@@ -275,7 +275,7 @@ export const useUpdateDiet = (options?: IMutationOptions) => {
 };
 // DELETE //
 export const useDeleteDiet = () => {
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
   const dispatch = useDispatch();
   const handleError = useHandleError();
   const mutation = useMutation({

--- a/src/screens/Cart.tsx
+++ b/src/screens/Cart.tsx
@@ -9,7 +9,10 @@ import Accordion from 'react-native-collapsible/Accordion';
 // doobi util, redux, etc
 import colors from '../styles/colors';
 import {commaToNum, sumUpDietTotal} from '../util/sumUp';
-import {setCurrentDiet, setMenuActiveSection} from '../stores/slices/cartSlice';
+import {
+  setCurrentDiet,
+  setMenuActiveSection,
+} from '../stores/slices/commonSlice';
 import {SCREENWIDTH} from '../constants/constants';
 import {icons} from '../assets/icons/iconSource';
 import {getDietAddStatus} from '../util/getDietAddStatus';
@@ -41,7 +44,7 @@ const Cart = () => {
   // redux
   const dispatch = useDispatch();
   const {currentDietNo, menuActiveSection} = useSelector(
-    (state: RootState) => state.cart,
+    (state: RootState) => state.common,
   );
   const {shippingPrice} = useSelector((state: RootState) => state.order);
 
@@ -212,12 +215,10 @@ const Cart = () => {
         </ContentContainer>
 
         {/* 끼니 정보 요약 */}
-        <SummaryContainer>
-          <CartSummary
-            setMenuNumSelectShow={setMenuNumSelectShow}
-            setDietNoToNumControl={setDietNoToNumControl}
-          />
-        </SummaryContainer>
+        <CartSummary
+          setMenuNumSelectShow={setMenuNumSelectShow}
+          setDietNoToNumControl={setDietNoToNumControl}
+        />
       </ScrollView>
 
       {/* 주문 버튼 */}

--- a/src/screens/FoodDetail.tsx
+++ b/src/screens/FoodDetail.tsx
@@ -73,7 +73,7 @@ const ShowPart = ({clicked, table, data}: IShowPart) => {
 
 const FoodDetail = () => {
   // redux
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
 
   // navigation
   const navigation = useNavigation();
@@ -314,8 +314,8 @@ const InnerContainer = styled.View`
 `;
 
 const FoodImageContainer = styled.Image`
-  width: 100%;
-  height: 240px;
+  width: ${SCREENWIDTH}px;
+  height: ${SCREENWIDTH}px;
   background-color: ${colors.inactivated};
 `;
 const SellerText = styled(TextSub)`

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -7,7 +7,7 @@ import {useNavigation} from '@react-navigation/native';
 // doobi util, redux, etc
 import {useDispatch, useSelector} from 'react-redux';
 import {RootState} from '../stores/store';
-import {setCurrentDiet, setTotalFoodList} from '../stores/slices/cartSlice';
+import {setCurrentDiet, setTotalFoodList} from '../stores/slices/commonSlice';
 import {
   FOOD_LIST_ITEM_HEIGHT,
   HOME_FILTER_HEADER_HEIGHT,
@@ -48,7 +48,7 @@ const Home = () => {
   // redux
   const dispatch = useDispatch();
   const {currentDietNo, totalFoodListIsLoaded} = useSelector(
-    (state: RootState) => state.cart,
+    (state: RootState) => state.common,
   );
   const {applied: appliedSortFilter} = useSelector(
     (state: RootState) => state.sortFilter,

--- a/src/screens/Likes.tsx
+++ b/src/screens/Likes.tsx
@@ -25,7 +25,7 @@ import {useCallback} from 'react';
 
 const Likes = () => {
   // redux
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
 
   // react-query
   const {

--- a/src/screens/myPageScreen/orderHistory/OrderHistoryDetail.tsx
+++ b/src/screens/myPageScreen/orderHistory/OrderHistoryDetail.tsx
@@ -63,7 +63,7 @@ const OrderHistoryDetail = () => {
   const addMutation = useCreateDietDetail();
   const deleteMutation = useDeleteDietDetail();
   const nutrientType = ['calorie', 'carb', 'protein', 'fat'];
-  const {currentDietNo} = useSelector((state: RootState) => state.cart);
+  const {currentDietNo} = useSelector((state: RootState) => state.common);
   const [deleteAlertShow, setDeleteAlertShow] = useState(false);
   const {data: useListProductData} = useListProduct({
     dietNo: currentDietNo,

--- a/src/stores/slices/commonSlice.ts
+++ b/src/stores/slices/commonSlice.ts
@@ -6,6 +6,7 @@ export interface ICartState {
   currentDietNo: string;
   totalFoodList: IProductData[];
   totalFoodListIsLoaded: boolean;
+  platformDDItems: {value: string; label: string}[];
   nutrTooltipText: string;
   menuActiveSection: number[];
 }
@@ -14,12 +15,13 @@ const initialState: ICartState = {
   currentDietNo: '',
   totalFoodList: [],
   totalFoodListIsLoaded: false,
+  platformDDItems: [{value: '', label: '선택안함'}],
   nutrTooltipText: '',
   menuActiveSection: [],
 };
 
-export const cartSlice = createSlice({
-  name: 'cart',
+export const commonSlice = createSlice({
+  name: 'common',
   initialState,
   reducers: {
     setCurrentDiet: (state, action: PayloadAction<string>) => {
@@ -29,6 +31,20 @@ export const cartSlice = createSlice({
     setTotalFoodList: (state, action: PayloadAction<IProductData[]>) => {
       state.totalFoodList = action.payload;
       state.totalFoodListIsLoaded = true;
+
+      // action.payload 의 platformNm을 기준으로 중복되지 않는 platformNm을 platformDDItems 형태의 배열로 만들기
+      const platformNmSet = new Set(
+        action.payload.map(product => product.platformNm),
+      );
+      const platformNmArr = Array.from(platformNmSet);
+      const platformDDItems = platformNmArr.map(platformNm => ({
+        value: platformNm,
+        label: platformNm,
+      }));
+      state.platformDDItems = [
+        ...[{value: '', label: '선택안함'}],
+        ...platformDDItems,
+      ];
     },
     setNutrTooltipText: (state, action: PayloadAction<string>) => {
       state.nutrTooltipText = action.payload;
@@ -44,5 +60,5 @@ export const {
   setTotalFoodList,
   setNutrTooltipText,
   setMenuActiveSection,
-} = cartSlice.actions;
-export default cartSlice.reducer;
+} = commonSlice.actions;
+export default commonSlice.reducer;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -2,7 +2,7 @@ import {configureStore} from '@reduxjs/toolkit';
 
 import userInputReducer from './slices/userInputSlice';
 import sortFilterReducer from './slices/sortFilterSlice';
-import cartReducer from './slices/cartSlice';
+import commonReducer from './slices/commonSlice';
 import orderReducer from './slices/orderSlice';
 import commonAlertReducer from './slices/commonAlertSlice';
 
@@ -10,7 +10,7 @@ export const store = configureStore({
   reducer: {
     userInput: userInputReducer,
     sortFilter: sortFilterReducer,
-    cart: cartReducer,
+    common: commonReducer,
     order: orderReducer,
     commonAlert: commonAlertReducer,
   },

--- a/src/util/cart/autoMenu2.ts
+++ b/src/util/cart/autoMenu2.ts
@@ -423,6 +423,7 @@ interface IAutoMenu {
   baseLine: IBaseLineData | undefined;
   selectedCategoryIdx: number[];
   priceTarget: number[];
+  wantedPlatform: string;
 }
 export const makeAutoMenu2 = ({
   totalFoodList,
@@ -430,6 +431,7 @@ export const makeAutoMenu2 = ({
   baseLine,
   selectedCategoryIdx,
   priceTarget,
+  wantedPlatform,
 }: IAutoMenu): Promise<{
   sum: number[];
   recommendedFoods: IProductData[];
@@ -460,7 +462,6 @@ export const makeAutoMenu2 = ({
         // 추천할 식품 개수 정하기
         shuffle(targetNumArr);
         const targetNum = targetNumArr[0];
-
         for (let currentNum = 0; currentNum < targetNum; currentNum++) {
           availableFoods = getAvailableFoods({
             foods: availableFoods,
@@ -473,6 +474,19 @@ export const makeAutoMenu2 = ({
           if (availableFoods.length === 0) {
             NO_FOOD_AVAILABLE = true;
             break;
+          }
+
+          // 원하는 판매자가 있는 경우 첫 추천 식품에 적용
+          const wantedPlatformFoods = availableFoods.filter(
+            food => food.platformNm === wantedPlatform,
+          );
+          if (currentNum === 0 && wantedPlatform !== '') {
+            if (wantedPlatformFoods.length === 0) {
+              NO_FOOD_AVAILABLE = true;
+              break;
+            }
+            currentMenu.push(getRandomFood(wantedPlatformFoods));
+            continue;
           }
           currentMenu.push(getRandomFood(availableFoods));
         }

--- a/src/util/reduxUtil.ts
+++ b/src/util/reduxUtil.ts
@@ -1,4 +1,4 @@
-import {IProduct} from '../stores/slices/cartSlice';
+import {IProduct} from '../stores/slices/commonSlice';
 
 export const hasProduct = (menu: Array<IProduct>, productNo: string) => {
   const arrOfProductNo = menu.map(product => product.productNo);


### PR DESCRIPTION
1. 자동구성 모달 <AutoDietModal.tsx>에 원하는 카테고리 대신 원하는 판매자 식품을 포함해서 끼니를 구성하는 기능 추가
2. <cartSlice.ts>는 기존 의미가 퇴색해 <commonSlice.ts>로 이름 변경 (툴팁이나 전체 식품리스트는 장바구니와 관련이 없음)
3. cartSummary container padding 수정
4. [FoodDetail] 식품 썸네일 크기 조정 (그냥 정사각형으로)

(23.12.11 added by 대갈딱딱이)