### PR TITLE
[FEAT] : change AccordionInactiveHeader subTitle

### DIFF
--- a/src/components/cart/AccordionInactiveHeader.tsx
+++ b/src/components/cart/AccordionInactiveHeader.tsx
@@ -85,23 +85,27 @@ const AccordionInactiveHeader = ({
       <LeftBar backgroundColor={barColor} />
 
       {/* 현재 구성중인 끼니 툴팁 */}
-      <DTooltip
+      {/* <DTooltip
         tooltipShow={currentDietNo === dietNo}
         text="현재 구성중인 끼니"
         boxTop={-14}
         boxLeft={22}
         triangleLeft={18}
-      />
+      /> */}
 
       {/* accordionInactiveHeader Content */}
       <Col style={{flex: 1, marginLeft: 16}}>
         {/* 끼니, 가격, 식품 수 */}
         <MenuSeq>{dietSeq}</MenuSeq>
-        <FoodNoAndPrice>
-          {numOfFoods !== 0
-            ? `${commaToNum(priceSum)}원 (${numOfFoods}가지 식품)`
-            : `식품을 담아보세요`}
-        </FoodNoAndPrice>
+        {numOfFoods === 0 ? (
+          <FoodNoAndPrice>
+            <AutoMenuText>자동구성을 이용해보세요</AutoMenuText>
+          </FoodNoAndPrice>
+        ) : (
+          <FoodNoAndPrice>
+            {commaToNum(priceSum)}원 ({numOfFoods}가지 식품)
+          </FoodNoAndPrice>
+        )}
       </Col>
 
       {/* 끼니수량 - 수량선택버튼 */}
@@ -171,6 +175,11 @@ const MenuSeq = styled(TextMain)`
 const FoodNoAndPrice = styled(TextSub)`
   font-size: 14px;
   margin-top: 4px;
+`;
+
+const AutoMenuText = styled(TextMain)`
+  font-size: 14px;
+  color: ${colors.main};
 `;
 
 const MenuDeleteBtn = styled.TouchableOpacity`

--- a/src/components/cart/Menu.tsx
+++ b/src/components/cart/Menu.tsx
@@ -137,14 +137,18 @@ const Menu = ({
           </BtnSmall>
         </SelectedDeleteRow>
       )}
-      <HorizontalLine style={{marginTop: 16}} />
 
       {/* 현재 끼니 식품들 */}
-      <CartFoodList
-        selectedFoods={selectedFoods}
-        setSelectedFoods={setSelectedFoods}
-        dietNo={dietNo}
-      />
+      {dietDetailData.length > 0 && (
+        <>
+          <HorizontalLine style={{marginTop: 16}} />
+          <CartFoodList
+            selectedFoods={selectedFoods}
+            setSelectedFoods={setSelectedFoods}
+            dietNo={dietNo}
+          />
+        </>
+      )}
 
       {/* 자동구성 버튼, 모달 */}
       <AutoMenuBtn


### PR DESCRIPTION
1. 자동구성을 유도하기 위한 텍스트 subTitle로 변경
2. AccordionContent 자동구성 버튼 위 마진, horizontalLine도 식품 없을 때는 제거
3. 현재 구성중인 끼니 tooltip 제거 (inactiveHeader leftbar로 충분하다고 판단)

(23.12.23 added by 대갈딱딱이)