### PR TITLE
[FIX] : 에러 알럿창에서 특정 에러의 경우 로그인으로 돌아가지 않는 문제 발생

### DIFF
--- a/src/components/common/error/ErrorAlert.tsx
+++ b/src/components/common/error/ErrorAlert.tsx
@@ -5,27 +5,30 @@ import {RootState} from '../../../stores/store';
 import {errorActionByCode} from '../../../util/handleError';
 import DAlert from '../alert/DAlert';
 import RequestAlertContent from '../alert/RequestAlertContent';
-import {useQueryErrorResetBoundary} from '@tanstack/react-query';
-const ErrorAlert = props => {
+import {queryClient} from '../../../query/store';
+
+const ErrorAlert = () => {
   // navigation
-  const {navigate} = useNavigation();
+  const {reset} = useNavigation();
   const {errorCode} = useSelector((state: RootState) => state.commonAlert);
   const dispatch = useDispatch();
-  const {reset} = useQueryErrorResetBoundary();
   return (
     <>
       <DAlert
         alertShow={errorCode ? true : false}
         onConfirm={() => {
-          errorCode === 500
-            ? reset()
-            : errorCode &&
-              errorActionByCode[errorCode] &&
-              errorActionByCode[errorCode](navigate);
+          errorCode && errorActionByCode[errorCode]
+            ? errorActionByCode[errorCode](reset)
+            : reset({
+                index: 0,
+                routes: [{name: 'Login'}],
+              });
           dispatch(closeCommonAlert());
+          queryClient.invalidateQueries();
         }}
         onCancel={() => {
           dispatch(closeCommonAlert());
+          queryClient.invalidateQueries();
         }}
         NoOfBtn={1}
         renderContent={() => <RequestAlertContent />}

--- a/src/navigators/RootStackNav.tsx
+++ b/src/navigators/RootStackNav.tsx
@@ -41,6 +41,7 @@ const RootStackNav = () => {
       onError: handleError,
     },
     mutations: {
+      retry: 0,
       onError: handleError,
     },
   });

--- a/src/query/queries/address.ts
+++ b/src/query/queries/address.ts
@@ -61,7 +61,6 @@ export const useUpdateAddress = () => {
 };
 //DELETE
 export const useDeleteAddress = () => {
-  const handleError = useHandleError();
   const mutation = useMutation({
     mutationFn: (addrNo: string) =>
       mutationFn(`${DELETE_ADDRESS}/${addrNo}`, 'delete'),
@@ -69,7 +68,6 @@ export const useDeleteAddress = () => {
       console.log('주소 삭제 성공');
       queryClient.invalidateQueries({queryKey: [LIST_ADDRESS]});
     },
-    onError: error => handleError(error),
   });
   return mutation;
 };

--- a/src/query/queries/baseLine.ts
+++ b/src/query/queries/baseLine.ts
@@ -26,9 +26,6 @@ export const useCreateBaseLine = () => {
       queryClient.invalidateQueries({queryKey: [BASE_LINE]});
       console.log('생성');
     },
-    onError: error => {
-      console.log(error);
-    },
   });
   return mutation;
 };
@@ -60,9 +57,6 @@ export const useUpdateBaseLine = () => {
     onSuccess: res => {
       queryClient.invalidateQueries({queryKey: [BASE_LINE]});
       console.log('수정', res);
-    },
-    onError: error => {
-      console.log(error);
     },
   });
   return mutation;

--- a/src/query/queries/member.ts
+++ b/src/query/queries/member.ts
@@ -20,9 +20,6 @@ export const useDeleteUser = () => {
       queryClient.removeQueries([]);
       // queryClient.invalidateQueries([]);
     },
-    onError: e => {
-      console.log('delete error', e);
-    },
   });
 
   return mutation;

--- a/src/query/queries/order.ts
+++ b/src/query/queries/order.ts
@@ -32,9 +32,6 @@ export const useCreateOrder = () => {
       queryClient.invalidateQueries({queryKey: [DIET_DETAIL]});
       queryClient.invalidateQueries({queryKey: [DIET_DETAIL_ALL]});
     },
-    onError: error => {
-      console.log('useCreateOrder: onError: ', error);
-    },
   });
   return mutation;
 };

--- a/src/query/queries/requestFn.ts
+++ b/src/query/queries/requestFn.ts
@@ -5,7 +5,7 @@ export const queryFn = async <T>(url: string): Promise<T> => {
   const {accessToken} = await getStoredToken();
   const requestConfig = {
     headers: {authorization: `Bearer ${accessToken}`},
-    timeout: 4000,
+    timeout: 2000,
   };
   const res = await axios.get(url, requestConfig);
   return res.data;
@@ -22,6 +22,7 @@ export const mutationFn = async <T>(
     method,
     headers: {authorization: `Bearer ${accessToken}`},
     data: requestBody,
+    timeout: 2000,
   };
   return axios(requestConfig).then(res => res.data);
 };

--- a/src/query/store.ts
+++ b/src/query/store.ts
@@ -10,6 +10,9 @@ export const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       suspense: true,
     },
+    mutations: {
+      retry: 0,
+    },
   },
 });
 

--- a/src/util/handleError.tsx
+++ b/src/util/handleError.tsx
@@ -8,18 +8,17 @@ import {queryClient} from '../query/store';
 
 // doobi Component
 
-// 에러 코드별 메시지 //
+// 임시 에러 코드별 메시지 //
 interface IConvertCodeToMsg {
   [key: number]: string;
 }
 export const convertCodeToMsg: IConvertCodeToMsg = {
-  500: `서버 오류가 발생했어요. 잠시후 다시 시도해주세요\n(errorCode: 500)`,
+  520: `알수없는 오류. 지속되면 문의 바랍니다\n(errorCode: 520)`,
+  500: `서버 오류가 발생했어요. 종료후 다시 시도해주세요\n(errorCode: 500)`,
   401: `다시 로그인을 해주세요`,
+  405: `다시 로그인을 해주세요`,
+  400: `다시 로그인을 해주세요`,
 };
-
-// const invalidateAllQueries = () => {
-//   queryClient.invalidateQueries();
-// };
 
 // 에러 코드별 실행 로직 //
 interface IErrorActionByCode {
@@ -27,29 +26,37 @@ interface IErrorActionByCode {
 }
 // TBD | 일단 다 로그인 창으로 이동시키고 나중에 분리
 export const errorActionByCode: IErrorActionByCode = {
-  500: (navigate: Function) => {
+  500: (reset: Function) => {
     // reset();
-    navigate('Login');
-    // invalidateAllQueries();
+    reset({
+      index: 0,
+      routes: [{name: 'Login'}],
+    });
   },
-  405: (navigate: Function) => {
-    navigate('Login');
-    // invalidateAllQueries();
+  405: (reset: Function) => {
+    reset({
+      index: 0,
+      route: [{name: 'Login'}],
+    });
   },
-  401: (navigate: Function) => {
-    navigate('Login');
-    // invalidateAllQueries();
+  401: (reset: Function) => {
+    reset({
+      index: 0,
+      route: [{name: 'Login'}],
+    });
   },
-  400: (navigate: Function) => {
-    navigate('Login');
-    // invalidateAllQueries();
+  400: (reset: Function) => {
+    reset({
+      index: 0,
+      route: [{name: 'Login'}],
+    });
   },
 };
-
+``;
 export const useHandleError = () => {
   const dispatch = useDispatch();
   const handleError = useCallback((error: any) => {
-    const errorCode = error.response?.status;
+    const errorCode = error.response?.status ? error.response?.status : 520;
     console.log('handleError.tsx:', errorCode);
     dispatch(openCommonAlert(errorCode));
   }, []);


### PR DESCRIPTION
1. 에러 알럿창에서 로그인으로 이동 시 모든 쿼리 초기화
2. reactquery queries 나 mutations에 직접 onError 정의할 경우는 queryClient 의 defaultOptions로 정의된 handleError가 실행되지 않음 => 사용자 지정의 경우 handleError를 직접 실행시키든가 => 아예 onError를 삭제해서 defaultOptions가 적용되도록 함

(23.12.30 added by 섭)