### PR TITLE
[FIX] : thirdInput에서 calorie 값 없어도 CTA버튼 활성화되는 문제 수정

### DIFF
--- a/src/query/queries/code.ts
+++ b/src/query/queries/code.ts
@@ -3,11 +3,11 @@ import {queryFn} from './requestFn';
 import {CODE} from '../keys';
 
 import {LIST_CODE} from './urls';
-import {ICode} from '../types/code';
+import {ICodeData} from '../types/code';
 
 // GET //
 export const useListCode = (codeNo: string) => {
-  return useQuery<ICode>({
+  return useQuery<ICodeData>({
     queryKey: [`${CODE}/${codeNo}`],
     queryFn: () => queryFn(`${LIST_CODE}/${codeNo}`),
     retry: 1,

--- a/src/stores/slices/userInputSlice.ts
+++ b/src/stores/slices/userInputSlice.ts
@@ -334,10 +334,10 @@ const userInputSlice = createSlice({
       state.bmrKnown.isValid = true;
       // ThirdInput !!!! thirdInput의 칼탄단지는 baseLine값 불러오는게 아니라 항상 다시 계산하는 값
       state.ratio.value = NUTR_RATIO_CD[0].cd;
-      state.calorie.value = '';
-      state.carb.value = '';
-      state.protein.value = '';
-      state.fat.value = '';
+      Object.assign(state.calorie, initialState.calorie);
+      Object.assign(state.carb, initialState.carb);
+      Object.assign(state.protein, initialState.protein);
+      Object.assign(state.fat, initialState.fat);
       // Mypage calorie, carb, protein, fat change input -> 마이페이지 변경 칼탄단지, 몸무게는 서버 baseLine 정보 불러오는 값
       const {calorie, carb, protein, fat} = action.payload;
       state.calorieChange.value = String(parseInt(calorie));
@@ -356,10 +356,10 @@ const userInputSlice = createSlice({
         {name: 'sportsSeqCd', value: sportsSeqCd},
         {name: 'sportsTimeCd', value: sportsTimeCd},
         {name: 'sportsStrengthCd', value: sportsStrengthCd},
-        {name: 'calorie', value: String(parseInt(calorie))},
-        {name: 'carb', value: String(parseInt(carb))},
-        {name: 'protein', value: String(parseInt(protein))},
-        {name: 'fat', value: String(parseInt(fat))},
+        {name: 'calorie', value: ''},
+        {name: 'carb', value: ''},
+        {name: 'protein', value: ''},
+        {name: 'fat', value: ''},
       ];
       loadList.forEach(({name, value}) => {
         if (!validateInput[name]) {


### PR DESCRIPTION
loadBaseLineData에서 calorie 값을 항상 state 초기값으로 설정해야하는데 loadlist에 서버에서 가져온 IBaseLineData의 calorie, carb, protein, fat 값을 넣어서 state를 초기화하지 못하고 valid한 값으로 확인됨
=> 초기값이나 빈 값으로 설정하도록 수정함

(24.02.09 : fixed by 섭)