### PR TITLE
[FIX] : 홈화면 searchText 초기화 시킬 때 자동으로 flatlist update 되도록 수정

### DIFF
--- a/src/components/home/FlatlistHeaderComponent.tsx
+++ b/src/components/home/FlatlistHeaderComponent.tsx
@@ -17,6 +17,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {
   applySortFilter,
   copySortFilter,
+  initializeSearch,
   updateSearch,
 } from '../../stores/slices/sortFilterSlice';
 import {RootState} from '../../stores/store';
@@ -111,7 +112,8 @@ const FlatlistHeaderComponent = ({
               />
               <SearchCancelBtn
                 onPress={() => {
-                  dispatch(updateSearch(''));
+                  dispatch(initializeSearch());
+                  dispatch(applySortFilter());
                   setSearchBarFocus(false);
                 }}>
                 <SearchCancelImage source={icons.cancelRound_24} />

--- a/src/stores/slices/sortFilterSlice.ts
+++ b/src/stores/slices/sortFilterSlice.ts
@@ -244,6 +244,9 @@ const sortFilterSlice = createSlice({
     updateSearch: (state, action: PayloadAction<string>) => {
       state.copied.filter.search = action.payload;
     },
+    initializeSearch: state => {
+      state.copied.filter.search = initialState.copied.filter.search;
+    },
 
     // 영양성분
     updateSelectedBtn: (
@@ -345,6 +348,7 @@ export const {
   initializePrice,
 
   updateSearch,
+  initializeSearch,
 
   initializeFilter,
   initializeSortFilter,


### PR DESCRIPTION
기존은 searchText를 초기화 시키면 사용자가 직접 flatlist를 맨 위에서
스크롤을 올려야 flatlist 다시 불러옴.
=> searchText 초기화 시키면 자동으로 flatlist 다시 불러오도록 수정

(24.02.09 : fixed by 섭)