### PR TITLE
[FEAT] : progressBar 부분 장바구니 화살표 위치 변경

### DIFF
--- a/src/components/cart/AccordionContent.tsx
+++ b/src/components/cart/AccordionContent.tsx
@@ -12,12 +12,7 @@ import {IDietDetailData} from '../../query/types/diet';
 import Menu from './Menu';
 import {SetStateAction} from 'react';
 import {commaToNum, sumUpPrice} from '../../util/sumUp';
-import {
-  HorizontalLine,
-  HorizontalSpace,
-  Row,
-  TextMain,
-} from '../../styles/styledConsts';
+import {HorizontalSpace, Row, TextMain} from '../../styles/styledConsts';
 import MenuNumSelect from './MenuNumSelect';
 
 interface IAccordionContent {
@@ -60,12 +55,7 @@ const AccordionContent = ({
       </Row>
       <HorizontalSpace height={8} />
       <NutrientsProgress dietDetailData={dietDetailData} />
-      <Menu
-        dietNo={dietNo}
-        dietDetailData={dietDetailData}
-        setDietNoToNumControl={setDietNoToNumControl}
-        setMenuNumSelectShow={setMenuNumSelectShow}
-      />
+      <Menu dietNo={dietNo} dietDetailData={dietDetailData} />
     </ContentBody>
   );
 };

--- a/src/components/cart/Menu.tsx
+++ b/src/components/cart/Menu.tsx
@@ -34,16 +34,9 @@ import MenuNumSelect from './MenuNumSelect';
 interface IMenu {
   dietNo: string;
   dietDetailData: IDietDetailData;
-  setDietNoToNumControl: React.Dispatch<SetStateAction<string>>;
-  setMenuNumSelectShow: React.Dispatch<SetStateAction<boolean>>;
 }
 
-const Menu = ({
-  dietNo,
-  dietDetailData,
-  setDietNoToNumControl,
-  setMenuNumSelectShow,
-}: IMenu) => {
+const Menu = ({dietNo, dietDetailData}: IMenu) => {
   // react-query
   const {data: baseLineData} = useGetBaseLine();
   const deleteDietDetailMutation = useDeleteDietDetail();

--- a/src/screens/FoodDetail.tsx
+++ b/src/screens/FoodDetail.tsx
@@ -158,8 +158,16 @@ const FoodDetail = () => {
     return makeTableData(productData, baseLineData);
   }, [baseLineData, productData]);
 
-  return !productData || !baseLineData ? (
-    <ActivityIndicator />
+  return !productData || !baseLineData || isFetching ? (
+    <SafeAreaView
+      style={{
+        flex: 1,
+        backgroundColor: 'white',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}>
+      <ActivityIndicator size={'large'} />
+    </SafeAreaView>
   ) : (
     <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
       <Container>

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -163,13 +163,7 @@ const Home = () => {
   return (
     <Container>
       {/* 끼니선택, progressBar section */}
-      {isBaseLineFetching === false &&
-      listDietLoading === false &&
-      productIsLoading === false ? (
-        <MenuSection />
-      ) : (
-        <ActivityIndicator />
-      )}
+      <MenuSection />
 
       <HomeContainer>
         {/* 검색결과 수 및 정렬 필터 */}


### PR DESCRIPTION
1. Menu component 사용하지 않는 props 제거 (setDietNoToNumControl, setMenuNumSelectShow)
2. 홈화면 progressBar에 accordion 적용
3. 홈화면 progressBar(장바구니) 열었을 때는 화살표가 컨테이너 맨 밑에 화살표가 있도록 수정

(24.02.15 added by 섭)