### PR TITLE
[FIX] : [Home] progressBar 에 tooltip 이 잘리는 이슈 해결

### DIFF
--- a/src/components/common/menuSection/MenuSection.tsx
+++ b/src/components/common/menuSection/MenuSection.tsx
@@ -33,7 +33,6 @@ import {
 } from '../../../query/queries/diet';
 import MenuNumSelect from '../../cart/MenuNumSelect';
 import {commaToNum, sumUpPrice} from '../../../util/sumUp';
-import {setNutrTooltipText} from '../../../stores/slices/commonSlice';
 
 const MenuSection = () => {
   // redux
@@ -75,7 +74,6 @@ const MenuSection = () => {
   // accordion
   // accordionUpdate
   const updateSections = (activeSections: number[]) => {
-    dispatch(setNutrTooltipText(''));
     setActiveSection(activeSections);
   };
 
@@ -128,15 +126,17 @@ const MenuSection = () => {
           </ProgressContainer>
         ),
         content: (
-          <MenuContainer>
+          // 툴팁잘림 => activeHeader paddingBottom에 + , content marginTop에 - 로 조절
+          <ProgressContainer style={{marginTop: -24}}>
             <Menu dietNo={currentDietNo} dietDetailData={dietDetailData} />
             <MenuContainerClose onPress={() => setActiveSection([])}>
               {isAccordionActive && <Arrow source={icons.arrowUp_20} />}
             </MenuContainerClose>
-          </MenuContainer>
+          </ProgressContainer>
         ),
         activeHeader: (
-          <ProgressContainer>
+          // 툴팁잘림 => activeHeader paddingBottom에 + , content marginTop에 - 로 조절
+          <ProgressContainer style={{paddingBottom: 24}}>
             {/* 끼니 수량조절 */}
             <>
               <Row

--- a/src/query/queries/diet.ts
+++ b/src/query/queries/diet.ts
@@ -6,6 +6,7 @@ import {queryClient} from '../store';
 import {
   setCurrentDiet,
   setMenuActiveSection,
+  setProgressTooltipShow,
 } from '../../stores/slices/commonSlice';
 import {useHandleError} from '../../util/handleError';
 import {
@@ -65,7 +66,10 @@ export const useCreateDiet = (options?: IMutationOptions) => {
       return {prevEmptyData};
     },
     onSuccess: data => {
-      console.log('createDiet success: ', data);
+      // progressTooltip을 끼니나 식품을 추가/삭제 할 경우에만 띄우기 위함.
+      // 툴팁 닫은 후에 화면 옮겼을 때 다시 뜨지 않도록 방지
+      dispatch(setProgressTooltipShow(true));
+
       options?.onSuccess && options?.onSuccess(data);
       // 현재 구성중인 끼니의 dietNo, dietIdx를 redux에 저장 => 장바구니와 동기화
       dispatch(setCurrentDiet(data.dietNo));
@@ -93,6 +97,8 @@ export const useCreateDiet = (options?: IMutationOptions) => {
 };
 
 export const useCreateDietDetail = (options?: IMutationOptions) => {
+  const dispatch = useDispatch();
+
   const onSuccess = options?.onSuccess;
   const handleError = useHandleError();
   const mutation = useMutation({
@@ -158,6 +164,10 @@ export const useCreateDietDetail = (options?: IMutationOptions) => {
       };
     },
     onSuccess: (data, {dietNo, food}) => {
+      // progressTooltip을 끼니나 식품을 추가/삭제 할 경우에만 띄우기 위함.
+      // 툴팁 닫은 후에 화면 옮겼을 때 다시 뜨지 않도록 방지
+      dispatch(setProgressTooltipShow(true));
+
       // 컴포넌트로부터 전달받은 onSuccess 실행
       onSuccess && onSuccess();
 
@@ -298,6 +308,10 @@ export const useDeleteDiet = () => {
       return {prevDietData, newDietData};
     },
     onSuccess: (data, {dietNo}: {dietNo: string}, context) => {
+      // progressTooltip을 끼니나 식품을 추가/삭제 할 경우에만 띄우기 위함.
+      // 툴팁 닫은 후에 화면 옮겼을 때 다시 뜨지 않도록 방지
+      dispatch(setProgressTooltipShow(true));
+
       // 끼니 삭제 후 현재 구성중인 끼니를 redux에 새로 저장 => 장바구니와 동기화
       const prevDietData = context?.prevDietData;
       if (!prevDietData) {
@@ -330,6 +344,7 @@ export const useDeleteDiet = () => {
 };
 
 export const useDeleteDietDetail = (options?: IMutationOptions) => {
+  const dispatch = useDispatch();
   const onSuccess = options?.onSuccess;
   const handleError = useHandleError();
   const mutation = useMutation({
@@ -392,6 +407,10 @@ export const useDeleteDietDetail = (options?: IMutationOptions) => {
       };
     },
     onSuccess: (data, {dietNo, productNo}) => {
+      // progressTooltip을 끼니나 식품을 추가/삭제 할 경우에만 띄우기 위함.
+      // 툴팁 닫은 후에 화면 옮겼을 때 다시 뜨지 않도록 방지
+      dispatch(setProgressTooltipShow(true));
+
       // 컴포넌트로부터 option으로 받은 onSuccess 실행
       onSuccess && onSuccess();
 

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -3,10 +3,10 @@ import {useCallback, useEffect, useState, useRef} from 'react';
 import {FlatList, Animated, ActivityIndicator} from 'react-native';
 import styled from 'styled-components/native';
 import {useNavigation} from '@react-navigation/native';
-
-// doobi util, redux, etc
 import {useDispatch, useSelector} from 'react-redux';
 import {RootState} from '../stores/store';
+
+// doobi util, const
 import {setCurrentDiet, setTotalFoodList} from '../stores/slices/commonSlice';
 import {
   FOOD_LIST_ITEM_HEIGHT,

--- a/src/stores/slices/commonSlice.ts
+++ b/src/stores/slices/commonSlice.ts
@@ -7,7 +7,7 @@ export interface ICartState {
   totalFoodList: IProductData[];
   totalFoodListIsLoaded: boolean;
   platformDDItems: {value: string; label: string}[];
-  nutrTooltipText: string;
+  progressTooltipShow: boolean;
   menuActiveSection: number[];
 }
 
@@ -16,7 +16,7 @@ const initialState: ICartState = {
   totalFoodList: [],
   totalFoodListIsLoaded: false,
   platformDDItems: [{value: '', label: '선택안함'}],
-  nutrTooltipText: '',
+  progressTooltipShow: true,
   menuActiveSection: [],
 };
 
@@ -26,6 +26,7 @@ export const commonSlice = createSlice({
   reducers: {
     setCurrentDiet: (state, action: PayloadAction<string>) => {
       state.currentDietNo = action.payload;
+      state.progressTooltipShow = true;
       // queryClient.invalidateQueries([PRODUCTS]);
     },
     setTotalFoodList: (state, action: PayloadAction<IProductData[]>) => {
@@ -46,8 +47,8 @@ export const commonSlice = createSlice({
         ...platformDDItems,
       ];
     },
-    setNutrTooltipText: (state, action: PayloadAction<string>) => {
-      state.nutrTooltipText = action.payload;
+    setProgressTooltipShow: (state, action: PayloadAction<boolean>) => {
+      state.progressTooltipShow = action.payload;
     },
     setMenuActiveSection: (state, action: PayloadAction<number[]>) => {
       state.menuActiveSection = action.payload;
@@ -58,7 +59,7 @@ export const commonSlice = createSlice({
 export const {
   setCurrentDiet,
   setTotalFoodList,
-  setNutrTooltipText,
+  setProgressTooltipShow,
   setMenuActiveSection,
 } = commonSlice.actions;
 export default commonSlice.reducer;


### PR DESCRIPTION
1. accordion activeHeader paddingbottom 24px accordion content marginTop -24px로 해결
2. tooltip 닫고 [FoodDetail]등 화면 옮길 때 기존 tooltip이 다시 뜨는 오류 해결 (redux에 끼니나 식품을 추가/삭제 할 때만 툴팁 띄우도록 상태값 추가)

(24.02.16 added by 섭)