### PR TITLE
[FIX] : [FoodDetail] 이전 페이지의 상품정보가 보이는 문제 수정

### DIFF
--- a/src/screens/FoodDetail.tsx
+++ b/src/screens/FoodDetail.tsx
@@ -96,6 +96,7 @@ const FoodDetail = () => {
 
   //state
   const [clicked, setClicked] = useState('식품상세');
+  const [isPageLoading, setIsPageLoading] = useState(true);
   const detailMenu = ['영양성분', '식품상세', '배송정책'];
 
   // etc
@@ -105,6 +106,9 @@ const FoodDetail = () => {
   // 식품마다 headerTitle바꾸기
   // TBD : route.params.item 타입 관련 해결 및 만약 null값일 시 에러처리
   useEffect(() => {
+    const waitPage = async () => {
+      setTimeout(() => setIsPageLoading(false), 500);
+    };
     const initializePage = async () => {
       const initialData = (await refetchProduct()).data;
       navigation.setOptions({
@@ -133,6 +137,7 @@ const FoodDetail = () => {
         },
       });
     };
+    waitPage();
     initializePage();
   }, [navigation]);
 
@@ -161,7 +166,7 @@ const FoodDetail = () => {
     return makeTableData(productData, baseLineData);
   }, [baseLineData, productData]);
 
-  return !productData || !baseLineData || isFetching ? (
+  return !productData || !baseLineData || isPageLoading ? (
     <SafeAreaView
       style={{
         flex: 1,


### PR DESCRIPTION
1. 상세페이지로 이동시 이전 상품정보가 보이는 문제 => 딜레이 0.5초 동안 인디케이터 적용
2. react-query isFetching 은 상품좋아요 버튼 누를 때도 적요이 돼서 사용하지 않음

(24.02.21 added by 섭)