### PR TITLE
[RELEASE]: version 1.0.16 (24.04.11)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -91,8 +91,8 @@ android {
         applicationId "com.subply.dietmate"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 20
-        versionName "1.0.14"
+        versionCode 22
+        versionName "1.0.16"
     }
 
    

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dietmate",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/screens/autoMenu/AutoMenu.tsx
+++ b/src/screens/autoMenu/AutoMenu.tsx
@@ -61,7 +61,7 @@ const AutoMenu = () => {
   // 1. 이미 구성중인 끼니 있으면 끼니 선택 페이지에서 시작 || 카테고리선택 페이지에서 시작
   // 2. 한 끼니 자동구성이면 카테고리 선택 페이지에서 시작
   useEffect(() => {
-    if (!dTData) return;
+    if (!dTData || !dData) return;
     if (route?.params?.isOneMenuAuto) {
       setProgress([getPageIdx('Category')]);
       route?.params?.selectedOneDietNo &&
@@ -71,6 +71,7 @@ const AutoMenu = () => {
     }
     const menuLengthList = dTData.map((m: any) => m.length);
     if (menuLengthList.every((m: number) => m === 0)) {
+      setSelectedDietNo(dData.map(v => v.dietNo));
       setProgress([getPageIdx('Category')]);
     }
     setPageloaded(true);

--- a/src/screens/autoMenu/subScreens/Processing.tsx
+++ b/src/screens/autoMenu/subScreens/Processing.tsx
@@ -71,6 +71,7 @@ const Processing = ({
   const autoMenuType =
     isOneMenuAuto && nutrStatus === 'notEnough' ? 'add' : 'overwrite';
 
+  // 자동구성 customHook
   const {
     data: autoMenuResult,
     isError,

--- a/src/screens/change/ui/ChangeSummary.tsx
+++ b/src/screens/change/ui/ChangeSummary.tsx
@@ -21,19 +21,31 @@ interface IChangeSummary {
 }
 const ChangeSummary = ({foodToChange, selectedProduct}: IChangeSummary) => {
   const nutrOriginal = [
-    {name: '칼로리', value: Number(foodToChange?.calorie), unit: 'kcal'},
-    {name: '탄수화물', value: Number(foodToChange?.carb), unit: 'g'},
-    {name: '단백질', value: Number(foodToChange?.protein), unit: 'g'},
-    {name: '지방', value: Number(foodToChange?.fat), unit: 'g'},
+    {name: '칼로리', value: parseInt(foodToChange?.calorie, 10), unit: 'kcal'},
+    {name: '탄수화물', value: parseInt(foodToChange?.carb, 10), unit: 'g'},
+    {name: '단백질', value: parseInt(foodToChange?.protein, 10), unit: 'g'},
+    {name: '지방', value: parseInt(foodToChange?.fat, 10), unit: 'g'},
   ];
 
   const nutrChanged = !selectedProduct
     ? []
     : [
-        {name: '칼로리', value: Number(selectedProduct?.calorie), unit: 'kcal'},
-        {name: '탄수화물', value: Number(selectedProduct?.carb), unit: 'g'},
-        {name: '단백질', value: Number(selectedProduct?.protein), unit: 'g'},
-        {name: '지방', value: Number(selectedProduct?.fat), unit: 'g'},
+        {
+          name: '칼로리',
+          value: parseInt(selectedProduct?.calorie, 10),
+          unit: 'kcal',
+        },
+        {
+          name: '탄수화물',
+          value: parseInt(selectedProduct?.carb, 10),
+          unit: 'g',
+        },
+        {
+          name: '단백질',
+          value: parseInt(selectedProduct?.protein, 10),
+          unit: 'g',
+        },
+        {name: '지방', value: parseInt(selectedProduct?.fat, 10), unit: 'g'},
       ];
 
   const nutrDiff = !selectedProduct

--- a/src/shared/ui/ShadowView.tsx
+++ b/src/shared/ui/ShadowView.tsx
@@ -3,8 +3,8 @@ import {ViewProps} from 'react-native';
 
 // 3rd
 import DropShadow from 'react-native-drop-shadow';
-import {Col} from './styledComps';
 import styled from 'styled-components/native';
+import colors from '../colors';
 
 interface IShadowView extends ViewProps {
   opacity?: number;
@@ -15,6 +15,7 @@ const ShadowView = (props: IShadowView) => {
     <Box {...boxProps}>
       <DropShadow
         style={{
+          backgroundColor: colors.white,
           shadowColor: '#000',
           shadowOffset: {
             width: 1,
@@ -31,4 +32,6 @@ const ShadowView = (props: IShadowView) => {
 
 export default ShadowView;
 
-const Box = styled.View``;
+const Box = styled.View`
+  background-color: ${colors.white};
+`;


### PR DESCRIPTION
0. v1.0.15 -> v1.0.16 으로 스킵
1. feature-sliced-design 적용 (아직 component(widget)<->shared ui 관계 모호)
2. 가이드페이지 제거
3. async-storage notShowAgain 로직 개선 기존 배열에서 (key: value) 형태로 전환
4. ios-build 파일 추가 (google-services.json, GoogleService-Info.plist) 등
5. userInput 개선 모든 고객정보 입력 분리
6. autoMenu 개선 (최대한 사용자가 가이드를 따라 식단을 구성할 수 있도록 함)

------ hotfix ------
1. 끼니 전체(5개) 자동구성 할 때 오류 해결
2. ios shadow 관련 warning 해결 (backgroundColor 추가)

(24.04.09 added by 섭)