### PR TITLE
[FIX]: createDiet 10개 이상 안되도록 수정

### DIFF
--- a/src/screens/diet/ui/CreateDietAlert.tsx
+++ b/src/screens/diet/ui/CreateDietAlert.tsx
@@ -45,7 +45,7 @@ const CreateDietAlert = ({
         action="setQty"
         currentQty={numOfCreateDiet}
         setQty={setNumOfCreateDiet}
-        maxQty={10}
+        maxQty={(dietData?.length && 10 - dietData.length) || 10}
       />
     </Container>
   );


### PR DESCRIPTION
1. 현재끼니 2개 있는데 10개 추가 가능했던 문제 수정 (최대 10개까지로!)

(24.05.13 added by 섭)