### PR TITLE
[REFACTOR]: login 로직 react-query로 변경 (network 오류는 RQ로 일괄처리 목표)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,15 +18,11 @@ import {link} from './src/shared/utils/linking';
 import {
   APP_STORE_URL,
   IS_ANDROID,
-  IS_IOS,
   PLAY_STORE_URL,
-  codePushOptions,
 } from './src/shared/constants';
 import {getLatestVersion} from './src/shared/api/queries/version';
-import CodePush from 'react-native-code-push';
 import {getNotShowAgainList} from './src/shared/utils/asyncStorage';
 import {setTutorialStart} from './src/features/reduxSlices/commonSlice';
-import ErrorPage from './src/screens/error/ErrorPage';
 
 const loadSplash = new Promise(resolve =>
   setTimeout(() => {
@@ -64,6 +60,17 @@ function App(): React.JSX.Element {
       await BootSplash.hide({fade: true});
     });
   }, []);
+
+  useEffect(() => {
+    if (!isNetworkError) return;
+    if (navigationRef.isReady()) {
+      navigationRef.reset({
+        index: 0,
+        routes: [{name: 'ErrorPage', params: {errorCode: 404}}],
+      });
+    }
+  }, [isNetworkError]);
+
   const visitStore = () => {
     IS_ANDROID ? link(PLAY_STORE_URL) : link(APP_STORE_URL);
     setIsUpdateNeeded(false);
@@ -72,7 +79,7 @@ function App(): React.JSX.Element {
     <QueryClientProvider client={queryClient}>
       <Provider store={store}>
         <NavigationContainer ref={navigationRef}>
-          {isNetworkError ? <ErrorPage /> : <RootStackNav />}
+          <RootStackNav />
           {/* 업데이트 알럿 */}
           <ErrorAlert />
           <DAlert

--- a/src/app/navigators/RootStackNav.tsx
+++ b/src/app/navigators/RootStackNav.tsx
@@ -198,6 +198,9 @@ const RootStackNav = () => {
           headerTitle: '',
         }}
       />
+
+      {/* 에러페이지 */}
+      <Stack.Screen name="ErrorPage" component={ErrorPage} />
     </Stack.Navigator>
   );
 };

--- a/src/screens/error/ErrorPage.tsx
+++ b/src/screens/error/ErrorPage.tsx
@@ -12,14 +12,30 @@ import {
   TextSub,
 } from '../../shared/ui/styledComps';
 import colors from '../../shared/colors';
+import {useRoute} from '@react-navigation/native';
 
+// 1. app splash 에서 버전 확인할 때 서버오류
+// 2. 로그인시 서버오류
+// 3. 일반 404 오류일 때 ErrorPage 띄우기
+// (나머지는 commonAlert로 처리)
 const ErrorPage = () => {
+  const route = useRoute();
+  console.log('ErrorPage: route: ', route);
+
+  const errorCode = route.params?.errorCode;
+  const errorText = errorCode
+    ? `서버에 문제가 있어요`
+    : `서버에 문제가 있거나\n네트워크가 불안정해요`;
+  const subText = errorCode
+    ? `빠른 시일 내에 해결할게요`
+    : `잠시 후 다시 이용해주세요`;
+
   return (
     <Container style={{alignItems: 'center', justifyContent: 'center'}}>
       <Col style={{alignItems: 'center'}}>
         <Icon source={icons.networkError_80} size={80} />
-        <ErrorText>{`서버에 문제가 있거나\n네트워크가 불안정해요`}</ErrorText>
-        <Sub>잠시 후 다시 이용해주세요</Sub>
+        <ErrorText>{errorText}</ErrorText>
+        <Sub>{subText}</Sub>
         <RestartBtn onPress={() => RNRestart.restart()}>
           <Icon source={icons.initialize_24} />
           <RestartText>재시작</RestartText>

--- a/src/screens/login/Login.tsx
+++ b/src/screens/login/Login.tsx
@@ -4,11 +4,7 @@ import {useEffect} from 'react';
 import styled from 'styled-components/native';
 import {useNavigation} from '@react-navigation/native';
 import colors from '../../shared/colors';
-import {
-  kakaoLogin,
-  validateToken,
-  guestLogin,
-} from '../../shared/api/queries/token';
+import {validateToken} from '../../shared/api/queries/token';
 import AppleLogin from './ui/AppleLogin';
 
 // doobi util, redux, etc
@@ -19,11 +15,7 @@ import {useGetBaseLine} from '../../shared/api/queries/baseLine';
 // doobi Component
 import {BtnCTA, BtnText, TextMain} from '../../shared/ui/styledComps';
 import {IS_IOS} from '../../shared/constants';
-
-const login: {[key: string]: Function} = {
-  kakao: kakaoLogin,
-  guest: guestLogin,
-};
+import {ILoginType, useLoginByType} from '../../shared/api/queries/login';
 
 const Login = () => {
   // navigation
@@ -32,11 +24,12 @@ const Login = () => {
   // react-query
   const {data: guestYnData} = useGetGuestYn();
   const {refetch} = useGetBaseLine({enabled: false});
+  const loginByTypeMutation = useLoginByType();
 
   // kakaoLogin || guest login (플레이스토어, 앱스토어, 카드사 심사용: 서버 값으로 사용유무 결정)
-  const signIn = async (option: string): Promise<void> => {
-    let loginData = await login[option]();
-    if (loginData === undefined) return;
+  const signIn = async (option: ILoginType): Promise<void> => {
+    const res = await loginByTypeMutation.mutateAsync({type: option});
+    if (!res) return;
     const baseLineData = await refetch().then(res => res.data);
     baseLineData && navigateByUserInfo(baseLineData, navigation);
   };

--- a/src/screens/login/ui/AppleLogin.tsx
+++ b/src/screens/login/ui/AppleLogin.tsx
@@ -5,29 +5,24 @@ import {View} from 'react-native';
 import appleAuth, {
   AppleButton,
 } from '@invertase/react-native-apple-authentication';
-import styled from 'styled-components/native';
-import {BtnCTA, BtnText} from '../../../shared/ui/styledComps';
-import colors from '../../../shared/colors';
-import {
-  kakaoLogin,
-  validateToken,
-  guestLogin,
-} from '../../../shared/api/queries/token';
 
 // doobi util, redux, etc
 import {navigateByUserInfo} from '../util/navigateByUserInfo';
 //react-query
 import {useGetBaseLine} from '../../../shared/api/queries/baseLine';
 import {useNavigation} from '@react-navigation/native';
+import {useLoginByType} from '../../../shared/api/queries/login';
 
 function AppleLogin() {
+  // react-query
+  const loginByTypeMutation = useLoginByType();
   const {refetch} = useGetBaseLine({enabled: false});
   const navigation = useNavigation();
 
   //check apple login & navigate screen
   const signInWithApple = async (): Promise<void> => {
-    const GLdata = await guestLogin();
-    if (GLdata === undefined) return;
+    const GLdata = await loginByTypeMutation.mutateAsync({type: 'guest'});
+    if (!GLdata) return;
     const baseLineData = await refetch().then(res => res.data);
     baseLineData && navigateByUserInfo(baseLineData, navigation);
   };

--- a/src/shared/api/queries/guest.ts
+++ b/src/shared/api/queries/guest.ts
@@ -8,13 +8,8 @@ const queryFnGetGuestYn = async () => {
   const requestConfig = {
     timeout: AXIOS_TIMEOUT,
   };
-  try {
-    const res = await axios.get(GET_GUEST_YN, requestConfig);
-    return res.data;
-  } catch (e) {
-    console.log('queryFnGetGuestYn: ', e);
-  }
-  return {enableYn: 'N'};
+  const res = await axios.get(GET_GUEST_YN, requestConfig);
+  return res.data;
 };
 
 export const useGetGuestYn = () => {

--- a/src/shared/api/queries/login.ts
+++ b/src/shared/api/queries/login.ts
@@ -1,0 +1,52 @@
+import {useMutation} from '@tanstack/react-query';
+import {IQueryOptions} from '../types/common';
+import {KakaoOAuthToken, login} from '@react-native-seoul/kakao-login';
+import {getDoobiToken, getGuestToken} from './token';
+import {storeToken} from '../../utils/asyncStorage';
+import {useNavigation} from '@react-navigation/native';
+
+export type ILoginType = 'kakao' | 'guest';
+
+const loginMutation = async (type: ILoginType) => {
+  console.log('loginMtion start');
+  let accessToken = undefined;
+  let refreshToken = undefined;
+
+  // kakaoLogin
+  if (type === 'kakao') {
+    console.log('kakao login start');
+    const kakaoToken: KakaoOAuthToken = await login();
+    const kakaoAccessToken = kakaoToken?.accessToken;
+    const res = await getDoobiToken(kakaoAccessToken);
+    accessToken = res?.accessToken || undefined;
+    refreshToken = res?.refreshToken || undefined;
+  }
+
+  // guestLogin
+  if (type === 'guest') {
+    const res = await getGuestToken();
+    accessToken = res?.accessToken || undefined;
+    refreshToken = res?.refreshToken || undefined;
+  }
+
+  accessToken && refreshToken && (await storeToken(accessToken, refreshToken));
+  return accessToken;
+};
+
+export const useLoginByType = (options?: IQueryOptions) => {
+  const navigation = useNavigation();
+  const mutation = useMutation({
+    mutationFn: ({type}: {type: ILoginType}) => loginMutation(type),
+    onError: (error: Error) => {
+      // console.log('useLoginByType error: error.name: ', error.name);
+      // console.log('useLoginByType error: error.message: ', error.message);
+      const isKakaoError = error.message === 'user cancelled.';
+      if (isKakaoError) return;
+      navigation.reset({
+        index: 0,
+        routes: [{name: 'ErrorPage', params: {errorCode: 404}}],
+      });
+    },
+  });
+  return mutation;
+};

--- a/src/shared/api/queries/token.ts
+++ b/src/shared/api/queries/token.ts
@@ -14,50 +14,16 @@ const requestConfig = {
 };
 
 export const getDoobiToken = async (kakaoAccessToken: string | null) => {
-  try {
-    const result = await axios.get(
-      `${GET_TOKEN}/${kakaoAccessToken}`,
-      requestConfig,
-    );
-    return result?.status === 200 ? result.data : undefined;
-  } catch (e) {
-    console.log('getDoobiToken error: ', e);
-  }
+  const result = await axios.get(
+    `${GET_TOKEN}dddd/${kakaoAccessToken}`,
+    requestConfig,
+  );
+  return result?.status === 200 ? result.data : undefined;
 };
 
 export const getGuestToken = async () => {
-  try {
-    const result = await axios.get(`${GET_GUEST}`, requestConfig);
-    return result?.status === 200 ? result.data : undefined;
-  } catch (e) {
-    console.log('getGuestToken error: ', e);
-  }
-};
-
-export const kakaoLogin = async () => {
-  console.log('kakaoLogin start');
-  try {
-    const kakaoToken: KakaoOAuthToken = await login();
-    const kakaoAccessToken = kakaoToken?.accessToken;
-    const {accessToken, refreshToken} = await getDoobiToken(kakaoAccessToken);
-    if (accessToken && refreshToken)
-      await storeToken(accessToken, refreshToken);
-    return accessToken;
-  } catch (e) {
-    console.log('kakaoLoginError: ', e);
-  }
-};
-
-export const guestLogin = async () => {
-  console.log('guestLogin start');
-  try {
-    const {accessToken, refreshToken} = await getGuestToken();
-    if (accessToken && refreshToken)
-      await storeToken(accessToken, refreshToken);
-    return accessToken;
-  } catch (e) {
-    console.log('guestLogin error: ', e);
-  }
+  const result = await axios.get(`${GET_GUEST}`, requestConfig);
+  return result?.status === 200 ? result.data : undefined;
 };
 
 export const validateToken = async () => {

--- a/src/shared/utils/handleError.tsx
+++ b/src/shared/utils/handleError.tsx
@@ -11,9 +11,10 @@ interface IConvertCodeToMsg {
 export const convertCodeToMsg: IConvertCodeToMsg = {
   520: `알수없는 오류. 지속되면 문의 바랍니다\n(errorCode: 520)`,
   500: `서버 오류가 발생했어요. 종료후 다시 시도해주세요\n(errorCode: 500)`,
-  401: `다시 로그인을 해주세요\n(errorCode: 401)`,
-  405: `다시 로그인을 해주세요\n(errorCode: 405)`,
   400: `다시 로그인을 해주세요\n(errorCode: 400)`,
+  401: `다시 로그인을 해주세요\n(errorCode: 401)`,
+  404: `서버 점점중입니다. 빠른 시일 내에 해결할게요\n(errorCode: 404)`,
+  405: `다시 로그인을 해주세요\n(errorCode: 405)`,
 };
 
 // 에러 코드별 실행 로직 //
@@ -58,6 +59,7 @@ export const handleError = (
   const errorCode =
     error.name === 'AxiosError' ? Number(error.message.slice(-3)) : 520;
 
+  console.log('handleError: ', errorCode, error.message, error.name, from);
   // 현재 로그인 화면인 경우를 제외하고 에러코드에 따른 알림창을 띄우기
   from !== 'Login' && store.dispatch(openCommonAlert(errorCode));
 };


### PR DESCRIPTION
network 오류 RQ로 일괄 처리할 수 있도록 login 로직도 react-query로 변경
(현재 App.tsx 에서 guestYn 가져오는 것, 최신버전 가져오는 것 제외하고는 모두 RQ)