### PR TITLE
[FIX]: 끼니삭제 로직 수정 (+7ee451 추가개선)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ yarn-error.log
 # Sentry
 # sentry.properties
 
+# .env
+.env

--- a/src/components/common/menuSection/MenuSection.tsx
+++ b/src/components/common/menuSection/MenuSection.tsx
@@ -66,7 +66,8 @@ const MenuSection = () => {
     !dTOData || Object.keys(dTOData).length === 0 ? true : false;
   const onDeleteDiet = () => {
     if (!dTOData) return;
-    dietNoToDelete && deleteDietMutation.mutate({dietNo: dietNoToDelete});
+    dietNoToDelete &&
+      deleteDietMutation.mutate({dietNo: dietNoToDelete, currentDietNo});
     setDeleteAlertShow(false);
   };
 

--- a/src/components/menuAccordion/MenuAcActiveHeader.tsx
+++ b/src/components/menuAccordion/MenuAcActiveHeader.tsx
@@ -24,7 +24,9 @@ interface IMenuAcActiveHeader {
 }
 const MenuAcActiveHeader = ({bLData, dietNo}: IMenuAcActiveHeader) => {
   // redux
-  const {totalFoodList} = useSelector((state: RootState) => state.common);
+  const {totalFoodList, currentDietNo} = useSelector(
+    (state: RootState) => state.common,
+  );
 
   // useState
   const [deleteAlertShow, setDeleteAlertShow] = useState(false);
@@ -36,7 +38,7 @@ const MenuAcActiveHeader = ({bLData, dietNo}: IMenuAcActiveHeader) => {
 
   // fn
   const onDietDelete = () => {
-    deleteDietMutation.mutate({dietNo: dDData[0].dietNo});
+    deleteDietMutation.mutate({dietNo: dDData[0].dietNo, currentDietNo});
     setDeleteAlertShow(false);
   };
 

--- a/src/components/menuAccordion/MenuAcInactiveHeader.tsx
+++ b/src/components/menuAccordion/MenuAcInactiveHeader.tsx
@@ -61,7 +61,7 @@ const MenuAcInactiveHeader = ({
   };
 
   const onDietDelete = () => {
-    deleteDietMutation.mutate({dietNo});
+    deleteDietMutation.mutate({dietNo, currentDietNo});
     setDeleteAlertShow(false);
   };
 

--- a/src/screens/home/NewHome.tsx
+++ b/src/screens/home/NewHome.tsx
@@ -192,10 +192,12 @@ const NewHome = () => {
   useEffect(() => {
     if (!isTutorialMode || tutorialProgress !== 'Start') return;
 
-    ctaBtnRef?.current?.measure((fx, fy, width, height, px, py) => {
-      scrollRef?.current?.scrollTo({y: 0, animated: true});
-      setTutorialCtaBtnPy(py);
-    });
+    const timeoutId = setTimeout(() => {
+      ctaBtnRef?.current?.measure((fx, fy, width, height, px, py) => {
+        scrollRef?.current?.scrollTo({y: 0, animated: true});
+        setTutorialCtaBtnPy(py);
+      });
+    }, 0);
 
     if (!isFocused) return;
     if (!dTOData) return;
@@ -206,6 +208,7 @@ const NewHome = () => {
     };
 
     deleteAllMenuAndStartTutorial();
+    return () => clearTimeout(timeoutId);
   }, [tutorialProgress, dTOData, menuNum]);
 
   return (


### PR DESCRIPTION
1. 현재 끼니와 삭제할 끼니의 dietNo가 같은 경우만 currentDietNo 변경
2. (+7ee451 추가개선) 렌더링 되기 전에 버튼 위치 계산 안하도록 setTimeout 추가