### PR TITLE
[FIX]: dietDetail을 서버와 동기화 할 때 (끼니자동구성) 잠깐동안 재고없다고 표시되는 문제 해결

### DIFF
--- a/src/components/menuAccordion/AccordionCtaBtns.tsx
+++ b/src/components/menuAccordion/AccordionCtaBtns.tsx
@@ -87,20 +87,17 @@ const AccordionCtaBtns = ({
         });
       });
     });
+    const createMutations = async () => {
+      for (const p of productToAddList) {
+        await createDietDetailMutation.mutateAsync({
+          food: p.food,
+          dietNo: p.dietNo,
+        });
+      }
+    };
+
     // 한꺼번에 추가할 mutation list
-    try {
-      // 자동구성된 식품 각 끼니에 추가
-      await Promise.all(
-        productToAddList.map(p =>
-          createDietDetailMutation.mutateAsync({
-            food: p.food,
-            dietNo: p.dietNo,
-          }),
-        ),
-      );
-    } catch (e) {
-      console.log('식품 추가 중 오류: ', e);
-    }
+    await createMutations();
   };
 
   const overwriteMenu = async (data: IProductData[][]) => {
@@ -127,7 +124,7 @@ const AccordionCtaBtns = ({
       );
       await addMenu(data);
     } catch (e) {
-      console.log('선택된 끼니 삭제 중 오류: ', e);
+      console.log('끼니 덮어쓰기 중 오류: ', e);
     }
   };
 
@@ -139,9 +136,6 @@ const AccordionCtaBtns = ({
 
     dispatch(setAutoMenuStatus(INITIAL_STATUS));
     let recommendedMenu: IProductData[][] = [];
-
-    // deley for 3seconds
-    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // 자동구성
     try {

--- a/src/screens/diet/Diet.tsx
+++ b/src/screens/diet/Diet.tsx
@@ -304,14 +304,6 @@ const Diet = () => {
   };
 
   // render
-  if (isDTObjLoading || isCreating) {
-    return (
-      <Container style={{justifyContent: 'center', alignItems: 'center'}}>
-        <ActivityIndicator size={24} color={colors.main} />
-      </Container>
-    );
-  }
-
   return (
     <Container
       style={{

--- a/src/shared/api/queries/diet.ts
+++ b/src/shared/api/queries/diet.ts
@@ -90,7 +90,14 @@ export const useCreateDietDetail = (options?: IMutationOptions) => {
         ? JSON.parse(JSON.stringify(prevDTOData))
         : {};
       const dietSeq = prevDTOData?.[dietNo]?.dietSeq ?? '';
-      newDTOData[dietNo].dietDetail.push({...food, qty: '1', dietNo, dietSeq});
+      newDTOData[dietNo].dietDetail.push({
+        ...food,
+        qty: '1',
+        dietNo,
+        dietSeq,
+        statusCd: 'SP012001',
+        statusNm: '판매중',
+      });
 
       // 3. Optimistically update to the new value
       // (실패할 경우 onError에서 이전 데이터로 돌려주기 -> 5번)


### PR DESCRIPTION
1. createDD optimistic update가 문제. 서버에 statusCd, statusNm 추가되었는데 optimistic update 할 때 이 값들을 추가 안함
2. 자동구성으로 바뀌는 끼니만 fetching하는 동안 activityIndicator 적용.
3. 한 끼니 자동구성의 경우 식품추가 mutation을 모두 synchronous하게 실행하도록 수정 (자동구성 로딩동안 한 식품씩 추가되는게 보이도록 함)