### PR TITLE
[FIX]: 튜토리얼건너뛰기 버튼 아이폰 상단에 겹침 수정.

### DIFF
--- a/src/screens/diet/util/modalContent.tsx
+++ b/src/screens/diet/util/modalContent.tsx
@@ -107,7 +107,12 @@ export const renderDTPContent: IRenderDTPContent = {
     <>
       <DSmallBtn
         btnText="튜토리얼 건너뛰기"
-        style={{position: 'absolute', top: 16, right: 0}}
+        style={{
+          position: 'absolute',
+          bottom: 40,
+          right: 0,
+          backgroundColor: colors.blackOpacity70,
+        }}
         onPress={() => {
           store.dispatch(setTutorialEnd());
           updateNotShowAgainList({key: 'tutorial', value: true});
@@ -129,7 +134,12 @@ export const renderDTPContent: IRenderDTPContent = {
     <>
       <DSmallBtn
         btnText="튜토리얼 건너뛰기"
-        style={{position: 'absolute', top: 16, right: 0}}
+        style={{
+          position: 'absolute',
+          bottom: 40,
+          right: 0,
+          backgroundColor: colors.blackOpacity70,
+        }}
         onPress={() => {
           store.dispatch(setTutorialEnd());
           updateNotShowAgainList({key: 'tutorial', value: true});
@@ -156,7 +166,12 @@ export const renderDTPContent: IRenderDTPContent = {
     <>
       <DSmallBtn
         btnText="튜토리얼 건너뛰기"
-        style={{position: 'absolute', top: 16, right: 0}}
+        style={{
+          position: 'absolute',
+          bottom: 40,
+          right: 0,
+          backgroundColor: colors.blackOpacity70,
+        }}
         onPress={() => {
           store.dispatch(setTutorialEnd());
           updateNotShowAgainList({key: 'tutorial', value: true});
@@ -195,7 +210,12 @@ export const renderDTPContent: IRenderDTPContent = {
     <>
       <DSmallBtn
         btnText="튜토리얼 건너뛰기"
-        style={{position: 'absolute', top: 16, right: 0}}
+        style={{
+          position: 'absolute',
+          bottom: 40,
+          right: 0,
+          backgroundColor: colors.blackOpacity70,
+        }}
         onPress={() => {
           store.dispatch(setTutorialEnd());
           updateNotShowAgainList({key: 'tutorial', value: true});
@@ -249,7 +269,12 @@ export const renderDTPContent: IRenderDTPContent = {
     <>
       <DSmallBtn
         btnText="튜토리얼 건너뛰기"
-        style={{position: 'absolute', top: 16, right: 0}}
+        style={{
+          position: 'absolute',
+          bottom: 40,
+          right: 0,
+          backgroundColor: colors.blackOpacity70,
+        }}
         onPress={() => {
           store.dispatch(setTutorialEnd());
           updateNotShowAgainList({key: 'tutorial', value: true});

--- a/src/screens/home/NewHome.tsx
+++ b/src/screens/home/NewHome.tsx
@@ -436,7 +436,12 @@ const NewHome = () => {
             <>
               <DSmallBtn
                 btnText="튜토리얼 건너뛰기"
-                style={{position: 'absolute', top: 16, right: 16}}
+                style={{
+                  position: 'absolute',
+                  bottom: 40,
+                  right: 16,
+                  backgroundColor: colors.blackOpacity70,
+                }}
                 onPress={() => {
                   dispatch(setTutorialEnd());
                   updateNotShowAgainList({key: 'tutorial', value: true});

--- a/src/shared/ui/DSmallBtn.tsx
+++ b/src/shared/ui/DSmallBtn.tsx
@@ -13,7 +13,12 @@ const DSmallBtn = ({btnText, iconSource, iconSize, ...props}: IDSmallBtn) => {
   return (
     <Btn {...props}>
       <BtnText>{btnText}</BtnText>
-      <Icon size={iconSize || 20} source={iconSource || icons.arrowRight_20} />
+      {iconSource && (
+        <Icon
+          size={iconSize || 20}
+          source={iconSource || icons.arrowRight_20}
+        />
+      )}
     </Btn>
   );
 };
@@ -21,7 +26,6 @@ const DSmallBtn = ({btnText, iconSource, iconSize, ...props}: IDSmallBtn) => {
 export default DSmallBtn;
 
 const Btn = styled.TouchableOpacity`
-  height: 32px;
   flex-direction: row;
   background-color: ${colors.white};
   border-radius: 5px;
@@ -30,7 +34,7 @@ const Btn = styled.TouchableOpacity`
   align-items: center;
   column-gap: 4px;
 
-  padding: 0 8px;
+  padding: 8px 16px;
 `;
 
 const BtnText = styled(TextSub)`


### PR DESCRIPTION
1. 건너뛰기버튼 덜 보이도록 색 변경
2. 하단으로 위치 옮김